### PR TITLE
update URL and naming for Monodevelop plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This repository previously contained the advanced editing support for F# for a n
 * [F# mode for Sublime Text](https://github.com/fsharp/sublime-fsharp-package)
 * [F# mode for Atom](https://github.com/fsprojects/FSharp.Atom)
 * Shared backend component [FSharp.AutoComplete](https://github.com/fsharp/FSharp.AutoComplete)
-* Monodevelop/Xamarin Studio support [FSharpMDXS](https://github.com/fsharp/FSharpMDXS)
+* [Monodevelop support(https://github.com/mono/monodevelop/tree/master/main/external/fsharpbinding)


### PR DESCRIPTION
Xamarin studio is no more, URL updated to point to the correct place and repo :)